### PR TITLE
Don't crash if irc_channels field is missing

### DIFF
--- a/backend/user.js
+++ b/backend/user.js
@@ -123,9 +123,11 @@ function insert_to_db(user_info, callback) {
         // irc channels go into a separate table
         var irc_string = 'INSERT INTO people_channels (person, channel) VALUES (?, ?);'
         var channels = user_info['irc_channels'];
-        channels.forEach(function(ch) {
-            db.run(irc_string, user_info['username'], ch, err_handler);
-        });
+        if (channels) {
+          channels.forEach(function(ch) {
+              db.run(irc_string, user_info['username'], ch, err_handler);
+          });
+        }
         callback();
     });
     db.close();


### PR DESCRIPTION
The backend began serving `503 Service Unavailable` after I submitted nick29581/rustaceans.org#90. As my entry didn't include an IRC info, I suspect this is what caused the failure.
