### PR TITLE
Add #rust-networking to the IRC channel list

### DIFF
--- a/rustaceans.org/index.html
+++ b/rustaceans.org/index.html
@@ -91,6 +91,7 @@
             <li><a href="irc://moznet/rust-crypto">#rust-crypto</a> is for discussion of cryptography in Rust;</li>
             <li><a href="irc://moznet/rust-osdev">#rust-osdev</a> is for people doing OS development in Rust;</li>
             <li><a href="irc://moznet/rust-webdev">#rust-webdev</a> is for people doing web development in Rust;</li>
+            <li><a href="irc://moznet/rust-networking">#rust-networking</a> is for people doing computer network development and programming in Rust;</li>
             <li><a href="irc://moznet/cargo">#cargo</a> is for discussion of Cargo, Rust's package manager;</li>
             <li><a href="irc://moznet/rust-offtopic">#rust-offtopic</a> is for general chit-chat amongst Rustaceans;</li>
             <li><a href="irc://moznet/servo">#servo</a> is for discussion of Servo, the browser engine written in Rust;</li>


### PR DESCRIPTION
Add a link to the new `#rust-networking` IRC channel.