### PR TITLE
Add Patreon support

### DIFF
--- a/backend/init.js
+++ b/backend/init.js
@@ -29,6 +29,7 @@ db.serialize(function() {
                                 discourse STRING,\
                                 reddit STRING,\
                                 twitter STRING,\
+                                patreon STRING,\
                                 blog STRING,\
                                 website STRING,\
                                 notes STRING,\

--- a/backend/rustaceans.js
+++ b/backend/rustaceans.js
@@ -147,6 +147,7 @@ var fields = [
     "discourse",
     "reddit",
     "twitter",
+    "patreon",
     "blog",
     "website",
     "notes"

--- a/backend/user.js
+++ b/backend/user.js
@@ -60,6 +60,7 @@ var fields = [
     ["discourse", true],
     ["reddit", true],
     ["twitter", true],
+    ["patreon", true],
     ["blog", true],
     ["website", true],
     ["notes", true]

--- a/rustaceans.org/src/user.js
+++ b/rustaceans.org/src/user.js
@@ -47,6 +47,10 @@ export const Card = (props) => {
     if (props.twitter) {
         twitter = <div className="row"><span className="key">twitter username</span><span className="value"><a href={"https://twitter.com/" + props.twitter}>{props.twitter}</a></span></div>
     }
+    let patreon = null;
+    if (props.patreon) {
+        patreon = <div className="row"><span className="key">patreon username</span><span className="value"><a href={"https://www.patreon.com/" + props.patreon}>{props.patreon}</a></span></div>
+    }
     let website = null;
     if (props.website) {
         website = <div className="row"><span className="key">website</span><span className="value"><a href={props.website}>{props.website}</a></span></div>
@@ -74,6 +78,7 @@ export const Card = (props) => {
         {discourse}
         {reddit}
         {twitter}
+        {patreon}
         {website}
         {blog}
         {email}


### PR DESCRIPTION
Support storing and displaying Patreon links. Inspired by
https://aturon.github.io/sponsor/

Note that this changes the database initialization in init.js; the
existing database will need updating accordingly.

In addition, the site should probably also have a page for "show all
users who have a Patreon username set", but this change doesn't add such
a page.